### PR TITLE
Add pagination to channel index page

### DIFF
--- a/music_feed/channel/routes.py
+++ b/music_feed/channel/routes.py
@@ -106,3 +106,29 @@ def delete(channel_id):
     db.session.commit()
 
     return redirect(url_for('.index'))
+
+######################################################################################################
+
+
+@channel_pages.route('/page', methods=('GET', ))
+def get_page():
+    last_channel_id = request.args.get("last_channel_id", None, int)
+    filter_tag_id = request.args.get("filter_tag", None, int)
+
+    print("last_channel_id: ", last_channel_id)
+    print("filter_tag_id: ", filter_tag_id)
+
+    channels = _channel_helper.get_Channels_Tagged_dict(
+        last_channel_id, filter_tag_id)
+
+    tags = []
+
+    for tag in Tag.get_all():
+        tags.append(tag.toDict())
+
+    return jsonify(
+        {
+            "channels": channels,
+            "tags": tags
+        }
+    )

--- a/music_feed/channel/templates_channel/channel_index.html
+++ b/music_feed/channel/templates_channel/channel_index.html
@@ -29,68 +29,76 @@
     Save All
 </button>
 
-<div class="channel-list-div">
-    <ul class="channel-list">
 
-        {% for channel in channels %}
-        <div id="channel_{{ channel.id }}" class="channel-list-entry" style="outline: 5px solid {{ channel.color }}; "
-            data-tagid="{% for tag in channel.tags %}{{tag.id}},{% endfor %}">
+<template id="channel_template">
+
+        <div id="channel_div" class="channel-list-entry" style="outline: 5px solid #ffffff; "
+            data-tagid="">
 
             <p>
-                <b>#{{ channel.id }}</b>
+                <b id="channel_id">#channel.id</b>
                 <b class="name">
-                    <a href="{{ channel.yt_link }}" target="_blank" rel="noopener noreferrer">
-                        &ensp; {{ channel.name }}
+                    <a id="channel_name" href="channel_link" target="_blank" rel="noopener noreferrer">
+                        &ensp; channel name
                     </a>
                 </b>
 
 
-                <a href="{{ url_for('.edit', channel_id=channel.id) }}">Edit</a>
+                <a id="channel_edit_link" href="">Edit</a>
 
             </p>
 
 
             <div class="profile-picture-box">
-                <img src="{{channel.profile_img_url}}" alt="profile img">
+                <img id="channel_image_link" src="" alt="profile img">
             </div>
 
 
-            <form id="edit_form_{{ channel.id }}" class="tag-list" method="POST"
-                action="{{ url_for('.edit_tags', channel_id=channel.id) }}">
+            <form id="tag_edit_form_id" class="tag-list" method="POST"
+                action="set_this">
                 <!-- <form method="POST" action="http://localhost:5000/channels/3/editv2/"> -->
 
                 <label for="tags">Choose a Tags:</label>
-                <select class="tag-list" name="tags" id="tags" multiple onchange="register_tag_change('{{ channel.id }}')">
-                    {% for tag in tags %}
-
-                    <option data-autoset-text-color='true' style="background-color: {{ tag.color }};"
-                        value="{{ tag.name }}" {% if tag in channel.tags %} selected {% endif %}>{{ tag.name }}
-                    </option>
-
-                    {% endfor %}
+                <select id="tag_edit_list" class="tag-list" name="tags" multiple onchange="register_tag_change('id')">
+                    <template id="tag_edit_option_template">
+                        <option id="tag_edit_option" data-autoset-text-color='true' style="background-color: #ffffff;"
+                            value="tag.name" selected>
+                            tag_name
+                        </option>
+                    </template>
                 </select>
 
-                <input value="Save" style="background-color: greenyellow; cursor: pointer;"
-                    onclick="send_tags_form('{{ channel.id }}')">
-                <!-- onclick="set_Filter_Parameter_on_form_action('edit_form_{{ channel.id }}')"> -->
+                <input id="tag_edit_submit_btn" value="Save" style="background-color: greenyellow; cursor: pointer;"
+                    onclick="send_tags_form('channel.id')">
+                <!-- onclick="set_Filter_Parameter_on_form_action('edit_form_channel.id')"> -->
                 <!-- onclick="return confirm('Are you sure you want to save this entry?')"> -->
 
             </form>
 
             <hr>
-            <form method="POST" action="{{ url_for('.delete', channel_id=channel.id) }}">
-                <input type="submit" value="Delete channel" style="width: fit-content; background-color: red;"
+            <form id="channel_delete_form" method="POST" action="url_for('.delete', channel_id=channel.id) ">
+                <input id="channel_delete_btn" type="submit" value="Delete channel" style="width: fit-content; background-color: red;"
                     onclick="return confirm('Are you sure you want to delete this entry?')">
             </form>
         </div>
-        {% endfor %}
-    </ul>
+</template>
 
+
+<div class="channel-list-div">
+    <ul  id="channel_list" class="channel-list">
+    </ul>
 </div>
 
+
+<button style="width: 80%; height: 50px;" onclick="get_more_channels()">
+    load more
+</button>
+
+
 <script src="/scripts/filter_tag.js"></script>
-<script src="/scripts/client_side_data_filter.js"></script>
 
 <script src="/scripts/edit_tags.js"></script>
+
+<script src="/scripts/load_channels.js"></script>
 
 {% endblock %}

--- a/music_feed/config/config.py
+++ b/music_feed/config/config.py
@@ -74,12 +74,14 @@ class Flask_Config(Badger_Config_Section):
 
 class Feed_Config(Badger_Config_Section):
     uploads_per_page: int
+    channels_per_page: int
 
     use_api: bool
     YT_API_KEY: str
 
     def setup(self):
         self.uploads_per_page = 4*20
+        self.channels_per_page = 20
 
         self.use_api = True
         self.YT_API_KEY = ""

--- a/music_feed/db_models/_upload.py
+++ b/music_feed/db_models/_upload.py
@@ -10,7 +10,8 @@ class Upload(db.Model, _Base_Mixin):
 
     yt_id = db.Column(db.String(100),  unique=True, nullable=False)
 
-    channel_id = db.Column(db.Integer, db.ForeignKey('channel.id'))
+    channel_id = db.Column(db.Integer, db.ForeignKey(
+        'channel.id'), nullable=False)
     channel = db.relationship('Channel', back_populates="uploads")
     # channel = None
 
@@ -28,13 +29,13 @@ class Upload(db.Model, _Base_Mixin):
     # https://stackoverflow.com/questions/35814211/how-to-add-a-custom-function-method-in-sqlalchemy-model-to-do-crud-operations
 
     @classmethod
-    def create(cls, yt_id, channel_id, title, thumbnail_url, dateTime, add_to_session:bool = True):
+    def create(cls, yt_id, channel_id, title, thumbnail_url, dateTime, add_to_session: bool = True):
         if Upload.query.filter_by(yt_id=yt_id).first():
             return "Warning: Upload already in DB: {}".format(title)
 
         new_upload = Upload(yt_id=yt_id, channel_id=channel_id, title=title,
                             thumbnail_url=thumbnail_url, dateTime=dateTime)
-        
+
         if add_to_session:
             db.session.add(new_upload)
 
@@ -53,7 +54,7 @@ class Upload(db.Model, _Base_Mixin):
     @hybrid_property
     def time_relativ(self) -> str:
         return get_relative_time(self.dateTime)
-    
+
     @hybrid_property
     def time_group(self) -> str:
         return get_time_group(self.dateTime)
@@ -71,7 +72,7 @@ class Upload(db.Model, _Base_Mixin):
         for tag in self.tags:
             if tag.id == tag_id:
                 return True
-            
+
         return False
 
     def toDict(self) -> dict:

--- a/music_feed/feed/_feed_helper.py
+++ b/music_feed/feed/_feed_helper.py
@@ -3,7 +3,6 @@ from ..db_models import Tag, Channel, Upload
 from music_feed.config import app_config
 
 
-
 ######################################################################################################
 
 
@@ -78,7 +77,8 @@ def _get_Tagged_Uploads_v1(last_upload_idx: int | None = None, filter_tag_id: in
                 # print("list length: ", len(tagged_uploads))
 
         if len(tagged_uploads) > app_config.yt_feed.uploads_per_page:
-            tagged_uploads = tagged_uploads[:app_config.yt_feed.uploads_per_page]
+            tagged_uploads = tagged_uploads[:
+                                            app_config.yt_feed.uploads_per_page]
 
         # print("list length: ", len(tagged_uploads))
         # print()
@@ -144,4 +144,3 @@ def get_Channels_Tagged_dict(filter_tag_id: int | None = None) -> list[Upload]:
         channel_list.append(channel.toDict(include_tags=True))
 
     return channel_list
-

--- a/music_feed/templates/base_app.html
+++ b/music_feed/templates/base_app.html
@@ -21,10 +21,10 @@
     </div>
 </body>
 
+<script src="/scripts/scroll_end_event.js"></script>
 <script src="/scripts/autoset_text_color.js"></script>
 
 <script>
-    
     // open url in new tab
     function new_tab(url){
         window.open(url, '_blank').focus();

--- a/music_feed/templates/scripts/load_channels.js
+++ b/music_feed/templates/scripts/load_channels.js
@@ -1,0 +1,210 @@
+
+
+
+document.addEventListener("page-end", function (e) {
+    console.log(e.detail); // Prints "Example of an event"
+    get_more_channels();
+});
+
+document.addEventListener("reload-filter-data", function (e) {
+    console.log(e.detail); // Prints "Example of an event"
+    reload_channels();
+});
+
+
+// Get more channels
+var channel_list = document.getElementById("channel_list");
+
+var last_channel_id = null;
+
+const channel_get_url = "/channels/page";          //"{{url_for('subfeed.channels')}}";
+
+
+function add_channels(data) {
+    var template = document.getElementById("channel_template");
+
+    channels_data = data["channels"]
+    tags_data = data["tags"]
+
+    for (let index = 0; index < channels_data.length; index++) {
+        const channel = channels_data[index];
+
+        // console.log(channel);
+
+        // // Add channel
+        var clone = template.content.cloneNode(true);
+
+        /////////////////////////////////////////////////////////////////////////////
+        var mainDIV = clone.getElementById("channel_div")
+        // mainDIV.onclick = function () { open_video(channel["url"]); };
+        mainDIV.id = "channel_" + channel["id"];
+
+        tags = channel["tags"];
+        var tag_string = "";
+        tags.forEach(tag => {
+            tag_string = tag_string + "" + tag["id"] + ",";
+        });
+        mainDIV.dataset.tagid = tag_string;
+
+        mainDIV.style = "outline: 5px solid " + channel["color"] + "; ";
+
+
+        /////////////////////////////////////////////////////////////////////////////
+        var id_text = clone.getElementById("channel_id");
+        id_text.textContent  = "#" + channel["id"];
+
+        var name_text = clone.getElementById("channel_name");
+        name_text.href = channel["yt_link"]
+        name_text.textContent = channel["name"]
+
+        var channel_edit_link = clone.getElementById("channel_edit_link");
+        channel_edit_link.href = "/channels/" + channel["id"] + "/edit"
+
+
+        /////////////////////////////////////////////////////////////////////////////
+        var image = clone.getElementById("channel_image_link")
+        image.src = channel["profile_img_url"]
+
+
+        /////////////////////////////////////////////////////////////////////////////
+        // tag_edit_form_id
+        /////////////////////////////////////////////////////////////////////////////
+        var tag_edit_form = clone.getElementById("tag_edit_form_id")
+        tag_edit_form.id = "edit_form_" + channel["id"]
+        tag_edit_form.action = "/channels/" + channel["id"] + "/edit_tags"
+
+        var tag_select = clone.getElementById("tag_edit_list")
+        tag_select.onchange = function() {
+            register_tag_change(channel["id"]);
+        };
+
+        var tag_edit_option_template = clone.getElementById("tag_edit_option_template")
+        
+        
+        tags = channel["tags"];
+        tags_data.forEach(tag => {
+            var tag_edit_option_clone = tag_edit_option_template.content.cloneNode(true);
+
+            tag_option = tag_edit_option_clone.getElementById("tag_edit_option")
+            tag_option.style="background-color: " + tag["color"] + ";"
+            tag_option.value = tag["name"]
+            tag_option.text = tag["name"]
+
+            if (channel["tags"].includes(tag)){
+                tag_option.selected = true
+            }else{
+                tag_option.selected = false
+            }
+
+            
+            tag_select.appendChild(tag_option);
+        });
+
+        var tag_edit_submit_btn = clone.getElementById("tag_edit_submit_btn")
+        tag_edit_submit_btn.onclick = function() {
+            send_tags_form(channel["id"]);
+        };
+        
+        
+        /////////////////////////////////////////////////////////////////////////////
+        // Channel delete Form
+        /////////////////////////////////////////////////////////////////////////////
+        var channel_delete_form = clone.getElementById("channel_delete_form")
+        channel_delete_form.action = "/channels/" + channel["id"] + "/delete"
+
+
+
+        /////////////////////////////////////////////////////////////////////////////
+
+
+        channel_list.appendChild(clone);
+
+        last_channel_id = channel["id"]
+    }
+
+    update_tagID_filtered();
+
+    // TODO handle no more new channels 
+}
+
+
+const getJSON = async url => {
+    const response = await fetch(url);
+    if (!response.ok) // check if response worked (no 404 errors etc...)
+        throw new Error(response.statusText);
+
+    const data = response.json(); // get JSON from the response
+    return data; // returns a promise, which resolves to this data value
+}
+
+const channel_update_delay_ms = 1000;
+var last_channel_time = +new Date() - (channel_update_delay_ms * 2);
+
+var temp_run_count = 0;
+
+function get_more_channels() {
+    console.log("Loading more channels...");
+
+    // rate limit incase of problems or something
+
+    const now = +new Date();
+    if (now - last_channel_time < channel_update_delay_ms) {
+        console.log("rate limit reached");
+        return
+    }
+
+    new_update_url = channel_get_url + "?";
+
+    if (last_channel_id != null) {
+        new_update_url = new_update_url + "last_channel_id=" + last_channel_id;
+    }
+
+    if (current_filter_tag_id != null) {
+        new_update_url = new_update_url + "&filter_tag=" + current_filter_tag_id;
+    }
+
+    console.log(new_update_url);
+    console.log(current_filter_tag_id);
+
+    getJSON(new_update_url).then(data => {
+
+        console.log(data);
+        add_channels(data);
+
+
+    }).catch(error => {
+        console.error(error);
+    });
+
+    temp_run_count++;
+    console.log("Run count: " + temp_run_count);
+
+    last_channel_time = now;
+}
+
+// reload when changing filter tag
+function reload_channels() {
+    console.log("reloading channels");
+    last_channel_id = null;
+
+    var channel_list = document.getElementById("channel_list");
+    channel_list.innerHTML = '';
+
+    // var all_channels = document.getElementsByClassName("music-grid-item")
+    // console.log(all_channels)
+    // console.log(all_channels.length)
+
+    // for (let index = 0; index < all_channels.length; index++) {
+    //     const channel = all_channels[index];
+    //     channel.remove();
+    // }
+
+    // console.log(all_channels)
+    console.log(channel_list)
+
+    get_more_channels();
+}
+
+
+
+get_more_channels();

--- a/music_feed/templates/scripts/scroll_end_event.js
+++ b/music_feed/templates/scripts/scroll_end_event.js
@@ -1,3 +1,4 @@
+// ! Trigger 'page-end' event, sub-scripts then load more data
 // https://stackoverflow.com/questions/10059888/detect-when-scroll-reaches-the-bottom-of-the-page-without-jquery
 // https://jsfiddle.net/W75mP/
 

--- a/music_feed/templates/sub_feed.html
+++ b/music_feed/templates/sub_feed.html
@@ -63,7 +63,6 @@
     load more
 </button>
 
-<script src="scripts/scroll_end_event.js"></script>
 <script src="/scripts/filter_tag.js"></script>
 
 <script src="/scripts/loader.js"></script>


### PR DESCRIPTION
To improve load times the `channels.index` page is now paginated, same as the `uploads.index` page.


Adds config value:
- `yt_feed.channels_per_page` : set the number of channels per page